### PR TITLE
Implement better arg handling

### DIFF
--- a/ArgParser.cs
+++ b/ArgParser.cs
@@ -43,7 +43,7 @@ namespace DartSharp
     private const string helpFlag = "--help";
     private readonly List<ArgFlag> flags = new()
     {
-      new(helpFlag, "Displays available options."),
+      new(helpFlag, "Displays available options. (Note: if running with dotnet run, to use this flag you'll need to call dotnet run -- --help)"),
       new(dirFlag, "Consumes a directory instead of individual files and runs all dart files through a selected processor"),
       new(explodeFlag, "Writes all Mock classes to their own files"),
       new(lintFlag, "WIP: Will analyze a given dart file and notify if there are unused args for any functions"),

--- a/ArgParser.cs
+++ b/ArgParser.cs
@@ -1,0 +1,119 @@
+namespace DartSharp
+{
+  enum ProgramMode
+  {
+    Garbage,
+    PrintHelp,
+    ExplodeMocks,
+    ArgumentUseLint,
+  }
+
+  readonly struct ArgFlag
+  {
+    public readonly string Flag;
+    public readonly string Description;
+
+    public ArgFlag(string flag, string desc)
+    {
+      Flag = flag;
+      Description = desc;
+    }
+  }
+
+  readonly struct ArgParserResult
+  {
+    public readonly IEnumerable<string> Files;
+    public readonly ProgramMode Mode;
+
+    public ArgParserResult(ProgramMode mode, IEnumerable<string> files)
+    {
+      Mode = mode;
+      Files = files;
+    }
+  }
+
+  class ArgParser
+  {
+    private const string dirFlag = "--dir";
+    private const string explodeFlag = "--explode";
+    private const string lintFlag = "--lint";
+    private const string helpFlag = "--help";
+    private readonly List<ArgFlag> flags = new()
+    {
+      new(helpFlag, "Displays available options."),
+      new(explodeFlag, "Writes all Mock classes to their own files"),
+      new(lintFlag, "WIP: Will analyze a given dart file and notify if there are unused args for any functions"),
+      new(dirFlag, "Consumes a directory instead of individual files and runs all dart files through a selected processor")
+    };
+
+    private List<string> flagParams => flags.Select((f) => f.Flag).ToList();
+
+    private List<string> GetFilesFromDirectory(string directory)
+    {
+      return Directory.GetFiles(directory, "*.dart", SearchOption.AllDirectories).ToList();
+    }
+
+    public ArgParserResult ParseArguments(string[] args)
+    {
+      var files = new List<string>();
+      var mode = ProgramMode.PrintHelp;
+
+      if (args.Length == 0)
+      {
+        return new ArgParserResult(mode, files);
+      }
+
+      for (int i = 0; i < args.Length; i++)
+      {
+        if (args[i] == helpFlag)
+          return new ArgParserResult(ProgramMode.PrintHelp, files);
+
+        // todo: maybe write to stderr or something if more than one processor flag
+        // is passed in?
+        if (args[i] == explodeFlag)
+        {
+          mode = ProgramMode.ExplodeMocks;
+          continue;
+        }
+
+        if (args[i] == lintFlag)
+        {
+          mode = ProgramMode.ArgumentUseLint;
+          continue;
+        }
+
+        if (args[i] == dirFlag && i != args.Length - 1)
+        {
+          files = files.Union(GetFilesFromDirectory(args[++i])).ToList();
+          continue;
+        }
+
+        if (args[i].EndsWith(".dart"))
+        {
+          files.Add(args[i]);
+          continue;
+        }
+
+        // If we reach here, an invalid file or argument has been passed in
+        // so set the mode to garbage and exit
+        mode = ProgramMode.Garbage;
+        // Hacky way to indicate which arg was invalid to the caller
+        files = new() { args[i] };
+        return new ArgParserResult(mode, files);
+      }
+
+      return new ArgParserResult(mode, files);
+    }
+
+    public void PrintHelp()
+    {
+      Console.WriteLine("Usage: DartCompiler [arguments] [files]");
+      Console.WriteLine("  (or) dotnet run [arguments] [files]");
+      Console.WriteLine("Arguments:");
+      foreach (var flag in flags)
+      {
+        Console.WriteLine($"  {flag.Flag,-20} {flag.Description}");
+      }
+    }
+  }
+}

--- a/ArgParser.cs
+++ b/ArgParser.cs
@@ -23,11 +23,13 @@ namespace DartSharp
   readonly struct ArgParserResult
   {
     public readonly IEnumerable<string> Files;
+    public readonly bool Verbose;
     public readonly ProgramMode Mode;
 
-    public ArgParserResult(ProgramMode mode, IEnumerable<string> files)
+    public ArgParserResult(ProgramMode mode, bool verbose, IEnumerable<string> files)
     {
       Mode = mode;
+      Verbose = verbose;
       Files = files;
     }
   }
@@ -37,13 +39,15 @@ namespace DartSharp
     private const string dirFlag = "--dir";
     private const string explodeFlag = "--explode";
     private const string lintFlag = "--lint";
+    private const string verboseFlag = "--verbose";
     private const string helpFlag = "--help";
     private readonly List<ArgFlag> flags = new()
     {
       new(helpFlag, "Displays available options."),
+      new(dirFlag, "Consumes a directory instead of individual files and runs all dart files through a selected processor"),
       new(explodeFlag, "Writes all Mock classes to their own files"),
       new(lintFlag, "WIP: Will analyze a given dart file and notify if there are unused args for any functions"),
-      new(dirFlag, "Consumes a directory instead of individual files and runs all dart files through a selected processor")
+      new(verboseFlag, "Print extra logging info while running this program. Useful for debugging."),
     };
 
     private List<string> flagParams => flags.Select((f) => f.Flag).ToList();
@@ -57,16 +61,23 @@ namespace DartSharp
     {
       var files = new List<string>();
       var mode = ProgramMode.PrintHelp;
+      var verbose = false;
 
       if (args.Length == 0)
       {
-        return new ArgParserResult(mode, files);
+        return new ArgParserResult(mode, verbose, files);
       }
 
       for (int i = 0; i < args.Length; i++)
       {
         if (args[i] == helpFlag)
-          return new ArgParserResult(ProgramMode.PrintHelp, files);
+          return new ArgParserResult(ProgramMode.PrintHelp, verbose, files);
+
+        if (args[i] == verboseFlag)
+        {
+          verbose = true;
+          continue;
+        }
 
         // todo: maybe write to stderr or something if more than one processor flag
         // is passed in?
@@ -99,10 +110,10 @@ namespace DartSharp
         mode = ProgramMode.Garbage;
         // Hacky way to indicate which arg was invalid to the caller
         files = new() { args[i] };
-        return new ArgParserResult(mode, files);
+        return new ArgParserResult(mode, verbose, files);
       }
 
-      return new ArgParserResult(mode, files);
+      return new ArgParserResult(mode, verbose, files);
     }
 
     public void PrintHelp()

--- a/Program.cs
+++ b/Program.cs
@@ -5,25 +5,6 @@ namespace DartSharp
   class Program
   {
 
-    public static List<string> GetFiles(List<string> args)
-    {
-      Console.WriteLine($"Provided {args.Count} arguments");
-      var files = args.Where(arg => arg.EndsWith(".dart"));
-
-      var dirArgIdx = args.IndexOf("--dir");
-      if (dirArgIdx >= 0 && dirArgIdx < args.Count - 1)
-      {
-        Console.WriteLine($"Scanning directory: {args[dirArgIdx + 1]}");
-        var extraFiles = Directory.GetFiles(args[dirArgIdx + 1], "*.dart", SearchOption.AllDirectories);
-        if (extraFiles != null)
-        {
-          files = files.Union(extraFiles);
-        }
-      }
-
-      return files.ToList();
-    }
-
     public static int Main(string[] args)
     {
       var argParser = new ArgParser();

--- a/Program.cs
+++ b/Program.cs
@@ -26,26 +26,31 @@ namespace DartSharp
 
     public static int Main(string[] args)
     {
-      var arguments = args.ToList();
-      var mode = ProgramMode.Garbage;
-      if (args.Length == 0)
+      var argParser = new ArgParser();
+      var argResults = argParser.ParseArguments(args);
+      var mode = argResults.Mode;
+      var files = argResults.Files;
+      var verbose = argResults.Verbose;
+
+      if (verbose)
       {
-        Console.WriteLine("Error: Please provide at least one file.");
+        Console.WriteLine("ArgParse Results:");
+        Console.WriteLine($"Mode: {argResults.Mode}");
+        Console.WriteLine($"Files: {argResults.Files.Aggregate("", (x, y) => x + ", " + y)}");
+      }
+
+      if (mode == ProgramMode.PrintHelp)
+      {
+        argParser.PrintHelp();
+        return 1;
+      }
+      else if (mode == ProgramMode.Garbage)
+      {
+        Console.WriteLine($"Invalid argument/file: {argResults.Files.First()}");
+        argParser.PrintHelp();
         return 1;
       }
 
-      if (args.Contains("--explode"))
-      {
-        arguments.Remove("--explode");
-        mode = ProgramMode.ExplodeMocks;
-      }
-      else if (args.Contains("--lint"))
-      {
-        arguments.Remove("--lint");
-        mode = ProgramMode.ArgumentUseLint;
-      }
-
-      var files = GetFiles(arguments);
       DartProcessor? processor = null;
       switch (mode)
       {
@@ -56,9 +61,8 @@ namespace DartSharp
           // Work in progress
           processor = new ParameterContainerTypeProcessor(files);
           break;
-        case ProgramMode.Garbage:
-          Console.WriteLine("Invalid mode");
-          return 1;
+        default:
+          break;
       }
 
       processor?.Process();

--- a/Program.cs
+++ b/Program.cs
@@ -24,13 +24,6 @@ namespace DartSharp
       return files.ToList();
     }
 
-    enum ProgramMode
-    {
-      Garbage,
-      ExplodeMocks,
-      ArgumentUseLint
-    }
-
     public static int Main(string[] args)
     {
       var arguments = args.ToList();


### PR DESCRIPTION
#### SUMMARY
Instead of haphazardly poking through the command line `args` in multiple places to determine which dart processor to run, instead we should haphazardly poke through the command line `args` in _one_ place to determine which dart processor to run.

#### HOW IT WAS FIXED
Moved argument parsing logic into its own unit

