### PR TITLE
remove extra semicolon

### DIFF
--- a/ArgumentHandling/CommandLineArgumentHandler.cs
+++ b/ArgumentHandling/CommandLineArgumentHandler.cs
@@ -58,7 +58,7 @@ namespace DartSharp.ArgumentHandling
                     if (!payload.TrySetProcessorFactory(processorFlag.CreateProcessor))
                     {
                         payload.Errors.Add($"Error: cannot set flag '{processorFlag.Flag}' as another process flag has been set already.");
-                        continue; ;
+                        continue;
                     }
                     continue;
                 }


### PR DESCRIPTION
#### SUMMARY
There is an extra semicolon after the `continue` statement on line 61 of `CommandLineArgumentHandler.cs`
#### HOW IT WAS FIXED
Removed it
#### TESTING SUGGESTIONS

#### REVIEWERS
@thomasmaloney-wk
